### PR TITLE
Added condition on file namespace

### DIFF
--- a/templates/file.twig
+++ b/templates/file.twig
@@ -3,9 +3,10 @@
 
 {% include 'phpdoc/license_phpdoc.twig' with { 'license_phpdoc': file.licensePhpdoc } only %}
 {% endif %}
-
+{% if file.namespace is not empty %}
 namespace {{ file.namespace }};
 
+{% endif %}
 {% include 'collection/fully_qualified_name_collection.twig' with {
     'fully_qualified_name_collection': file.allFullyQualifiedNames
 } only %}


### PR DESCRIPTION
If the classname got no namespace, will not add the "namespace ;" line at the beginning of the class.
