### PR TITLE
Custom twig templates should have higher priority than the base ones

### DIFF
--- a/spec/Memio/TwigTemplateEngine/TwigTemplateEngineSpec.php
+++ b/spec/Memio/TwigTemplateEngine/TwigTemplateEngineSpec.php
@@ -34,7 +34,7 @@ class TwigTemplateEngineSpec extends ObjectBehavior
     function it_can_have_more_paths(Twig_Environment $twig, Twig_Loader_Filesystem $loader)
     {
         $twig->getLoader()->willReturn($loader);
-        $loader->addPath(self::TEMPLATE_PATH)->shouldBeCalled();
+        $loader->prependPath(self::TEMPLATE_PATH)->shouldBeCalled();
 
         $this->addPath(self::TEMPLATE_PATH);
     }

--- a/src/Memio/TwigTemplateEngine/TwigTemplateEngine.php
+++ b/src/Memio/TwigTemplateEngine/TwigTemplateEngine.php
@@ -34,7 +34,7 @@ class TwigTemplateEngine implements TemplateEngine
      */
     public function addPath($path)
     {
-        $this->twig->getLoader()->addPath($path);
+        $this->twig->getLoader()->prependPath($path);
     }
 
     /**


### PR DESCRIPTION
Howdy,
[according to the documentation](http://memio.github.io/memio/doc/05-templates.html) it is possible to override base twig templates by copying template file and adding path to the custom templates directory to PrettyPrinter.

Unfortunately, right now base templates from memio/twig-template-engine are used by default, and any custom ones are used only if no template for given name is found in the base templates directory. Because of that, it is possible to use custom templates only after altering Memio base files.

Improved with simple change of addPath method in Memio\TwigTemplateEngine\TwigTemplateEngine class from:
`$this->twig->getLoader()->addPath($path);`
to
`$this->twig->getLoader()->prependPath($path);`
This way custom templates will have higher priority than the base ones and thus will be used by default.
