### PR TITLE
Filter namespaces of return types, keep nullable when filtering a namespace

### DIFF
--- a/spec/Memio/TwigTemplateEngine/TwigExtension/TypeSpec.php
+++ b/spec/Memio/TwigTemplateEngine/TwigExtension/TypeSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the memio/twig-template-engine package.
+ *
+ * (c) Loïc Faugeron <faugeron.loic@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Memio\TwigTemplateEngine\TwigExtension;
+
+use PhpSpec\ObjectBehavior;
+
+class TypeSpec extends ObjectBehavior
+{
+    public function it_can_be_a_non_object()
+    {
+        $this->filterNamespace('int')->shouldBe('int');
+    }
+
+    public function it_can_be_a_nullable_non_object()
+    {
+        $this->filterNamespace('?int')->shouldBe('?int');
+    }
+
+    public function it_can_be_an_object()
+    {
+        $this->filterNamespace('Vendor\Project\MyClass')->shouldBe('MyClass');
+    }
+
+    public function it_can_be_a_nullable_object()
+    {
+        $this->filterNamespace('?Vendor\Project\MyClass')->shouldBe('?MyClass');
+    }
+}

--- a/src/Memio/TwigTemplateEngine/TwigExtension/Type.php
+++ b/src/Memio/TwigTemplateEngine/TwigExtension/Type.php
@@ -61,12 +61,19 @@ class Type extends \Twig_Extension
 
     public function filterNamespace(string $stringType) : string
     {
+        $nullablePrefix = substr($stringType, 0, 1) === '?'
+            ? '?'
+            : '';
+
+        $stringType = ltrim(ltrim($stringType, '?'));
+
         $type = new ModelType($stringType);
         if (!$type->isObject()) {
-            return $stringType;
+            return $nullablePrefix.$stringType;
         }
+
         $fullyQualifiedName = new FullyQualifiedName($stringType);
 
-        return $fullyQualifiedName->getName();
+        return $nullablePrefix.$fullyQualifiedName->getName();
     }
 }

--- a/templates/collection/methods/pure_virtual.twig
+++ b/templates/collection/methods/pure_virtual.twig
@@ -3,5 +3,5 @@
     function {{ method.name }}({% include 'collection/argument_collection.twig' with {
         'argument_collection': method.allArguments,
         'length_restriction': 22 + method.name | length
-    } only %});
+    } only %}){{ method.returnType is not empty ? ' : ' ~ method.returnType : '' -}};
 {#- Trimming lines -#}

--- a/templates/collection/methods/pure_virtual.twig
+++ b/templates/collection/methods/pure_virtual.twig
@@ -3,5 +3,5 @@
     function {{ method.name }}({% include 'collection/argument_collection.twig' with {
         'argument_collection': method.allArguments,
         'length_restriction': 22 + method.name | length
-    } only %}){{ method.returnType is not empty ? ' : ' ~ method.returnType : '' -}};
+    } only %}){{ method.returnType is not empty ? ' : ' ~ method.returnType|filter_namespace : '' -}};
 {#- Trimming lines -#}

--- a/templates/method.twig
+++ b/templates/method.twig
@@ -5,6 +5,6 @@
     function {{ method.name }}({% include 'collection/argument_collection.twig' with {
         'argument_collection': method.allArguments,
         'length_restriction': 22 + method.name | length
-    } only %}){{ method.returnType is not empty ? ' : ' ~ method.returnType : '' -}}
+    } only %}){{ method.returnType is not empty ? ' : ' ~ method.returnType|filter_namespace : '' -}}
     {%- include 'method_body.twig' with { 'method': method } only %}
 {#- Trimming lines -#}


### PR DESCRIPTION
### Add return type template for interface methods.
This makes the template of pure_virtual.twig follow that of method.twig.

### Filter the namespace of method return types.
The return type is filtered in the same way as method argument types.

### Check for nullable when filtering namespaces.
The method filter_namespace() was not compatible with nullable types.

Before:
?Vendor\Project\MyClass became just MyClass
?DateTime stayed ?DateTime

After:
?Vendor\Project\MyClass becomes ?MyClass
?DateTime stays ?DateTime
